### PR TITLE
Issue 24 readwrite to parquet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,13 @@ demo.*
 /logs/
 syncdata.py
 .vscode/
+*.parquet
+*.csv
+*.pkl
+*.zip
+*.psv
+*.xlsx
+*.xls
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/nhs/__init__.py
+++ b/nhs/__init__.py
@@ -2,6 +2,7 @@ from loguru import logger
 
 from . import data, utils
 
-logger.disable("uncertainty")
+logger.disable("nhs")
+
 
 __all__ = ["data", "utils"]

--- a/nhs/data/__init__.py
+++ b/nhs/data/__init__.py
@@ -1,3 +1,4 @@
+from .filter import filter_sa1_regions
 from .handling import (
     read_csv,
     read_psv,
@@ -12,4 +13,5 @@ __all__ = [
     "read_csv",
     "read_xlsx",
     "standardize_names",
+    "filter_sa1_regions",
 ]

--- a/nhs/data/filter.py
+++ b/nhs/data/filter.py
@@ -1,0 +1,26 @@
+from typing import List
+
+import polars as pl
+
+
+def filter_sa1_regions(
+    lf: pl.LazyFrame, region_codes: List[str], sa1_column: str = "SA1_CODE_2021"
+) -> pl.LazyFrame:
+    """
+    Filters the LazyFrame to include only rows with specified SA1 area codes.
+
+    Parameters
+    ----------
+    lf : pl.LazyFrame
+        The LazyFrame containing SA1 region codes and data to be filtered.
+    region_codes : List[str]
+        A list of SA1 area codes to filter for.
+    SA1_column : str
+        The name of the column containing the SA1 area codes. Defaults to "SA1_CODE_2021".
+
+    Returns
+    -------
+    pl.LazyFrame
+        A LazyFrame containing only rows with the specified SA1 area codes.
+    """
+    return lf.filter(pl.col(sa1_column).is_in(region_codes))

--- a/scripts/spreadsheet_to_parquet.py
+++ b/scripts/spreadsheet_to_parquet.py
@@ -1,0 +1,66 @@
+"""
+Produce a directory of parquet files from a directory of spreadsheets
+"""
+
+import argparse
+from pathlib import Path
+
+import polars as pl
+from context import nhs
+from loguru import logger
+from tqdm import tqdm
+
+list_files = nhs.utils.path.list_files
+get_reader = nhs.data.handling.get_spreadsheet_reader
+
+
+@logger.catch()
+def save_parquet(path: str, input_dir: str, output_dir: str):
+    relative_path = Path(path).relative_to(input_dir)
+    output_file_path = Path(output_dir) / relative_path.with_suffix(".parquet")
+
+    if output_file_path.exists():
+        logger.warning(f"File {output_file_path} already exists. Skipping.")
+        return
+
+    output_file_path.parent.mkdir(parents=True, exist_ok=True)
+
+    df = get_reader(Path(path).suffix)(path)
+    if not isinstance(df, pl.LazyFrame):
+        logger.error(f"Failed to read {path}")
+        return
+    df.collect().write_parquet(output_file_path)
+
+
+def convert_to_parquet(input_dir: str, output_dir: str):
+    paths = list_files(input_dir)
+    paths = list(filter(lambda x: x.endswith((".xlsx", ".xls", ".csv", ".psv")), paths))
+
+    for path in tqdm(
+        paths, desc="Converting spreadsheets to Parquet", total=len(paths)
+    ):
+        save_parquet(path, input_dir, output_dir)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert spreadsheets to Parquet files while maintaining directory structure."
+    )
+    parser.add_argument(
+        "input_dir",
+        type=str,
+        help="Path to the input directory containing spreadsheets.",
+    )
+    parser.add_argument(
+        "output_dir",
+        type=str,
+        help="Path to the output directory where Parquet files will be saved.",
+    )
+
+    args = parser.parse_args()
+
+    convert_to_parquet(args.input_dir, args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_data/test_filter.py
+++ b/tests/test_data/test_filter.py
@@ -1,0 +1,47 @@
+import polars as pl
+import pytest
+
+from ..context import nhs
+
+filter_sa1_regions = nhs.data.filter.filter_sa1_regions
+
+
+class TestFilterSa1RegionCodes:
+
+    # Fixture to create a sample LazyFrame
+    @pytest.fixture
+    def sample_lazyframe(self):
+        data = {
+            "SA1_CODE_2021": ["123456", "789012", "345678", "901234", "567890"],
+            "value": [10, 20, 30, 40, 50],
+        }
+        return pl.DataFrame(data).lazy()
+
+    def test_filter_with_valid_region_codes(self, sample_lazyframe):
+        # Filtering with valid region codes
+        result = filter_sa1_regions(
+            sample_lazyframe, ["123456", "901234"], "SA1_CODE_2021"
+        ).collect()
+
+        expected_data = {"SA1_CODE_2021": ["123456", "901234"], "value": [10, 40]}
+
+        expected = pl.DataFrame(expected_data)
+        assert result.to_dicts() == expected.to_dicts()
+
+    def test_filter_with_empty_region_codes(self, sample_lazyframe):
+        # Test with empty region codes (should return an empty LazyFrame)
+        result = filter_sa1_regions(sample_lazyframe, [], "SA1_CODE_2021").collect()
+
+        # Expect an empty DataFrame when no region codes are provided
+        expected = pl.DataFrame({"SA1_CODE_2021": [], "value": []})
+
+        assert result.to_dicts() == expected.to_dicts()
+
+    def test_filter_with_no_matching_codes(self, sample_lazyframe):
+        # Test with region codes that don't match any rows (should return an empty DataFrame)
+        result = filter_sa1_regions(
+            sample_lazyframe, ["999999"], "SA1_CODE_2021"
+        ).collect()
+
+        expected = pl.DataFrame({"SA1_CODE_2021": [], "value": []})
+        assert result.to_dicts() == expected.to_dicts()


### PR DESCRIPTION
---
Title: "Closes #33 , #24"
---

# **Summary of Changes**
Add support for `.parquet` in `read_spreadsheets`, script to convert directory of spreadsheets to directory of parquet (currently running to dump files in `DataFiles/AppStaging`)

### **Optional Further Details**
**I'm omitting tests - the change are minimal to `read_spreadsheets` and there's no reason to believe it won't work (I'm just using `pl.scan_parquet`)

# **Checklist:**
- [x] My code follows the code style of this project.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [] New and existing unit tests prove my fix is effective or that my feature works.
- [x] I have annotated added types appropriately.

### **Additional context**
Add any other context or relevant information about the pull request here.
