### PR TITLE
Issue 30 filter building type

### DIFF
--- a/nhs/data/__init__.py
+++ b/nhs/data/__init__.py
@@ -3,7 +3,11 @@ from .allocation import (
     randomly_assign_census_features,
     sample_census_feature,
 )
-from .filter import filter_sa1_regions
+from .filter import (
+    filter_and_join_gnaf_frames,
+    filter_sa1_regions,
+    load_gnaf_files_by_states,
+)
 from .geography import join_coords_with_area, read_shapefile, to_geo_dataframe
 from .handling import (
     get_spreadsheet_reader,
@@ -21,6 +25,8 @@ __all__ = [
     "read_csv",
     "read_xlsx",
     "standardize_names",
+    "load_gnaf_files_by_states",
+    "filter_and_join_gnaf_frames",
     "filter_sa1_regions",
     "join_coords_with_area",
     "read_parquet",

--- a/nhs/data/filter.py
+++ b/nhs/data/filter.py
@@ -1,26 +1,182 @@
-from typing import List
+from typing import Literal
 
 import polars as pl
 
+from .handling import read_spreadsheets
 
-def filter_sa1_regions(
-    lf: pl.LazyFrame, region_codes: List[str], sa1_column: str = "SA1_CODE_2021"
+
+def load_gnaf_files_by_states(
+    gnaf_path: str,
+    states: list[
+        Literal["NSW", "ACT", "VIC", "QLD", "SA", "WA", "TAS", "NT", "OT"]
+    ] = [],
+) -> tuple[pl.LazyFrame, pl.LazyFrame]:
+    """
+    Load and filter ADDRESS_DEFAULT_GEOCODE and ADDRESS_DETAIL files for the given `states` from `gnaf_path`.
+
+    Parameters
+    ----------
+    gnaf_path : str
+        The directory path where the GNAF parquet files are stored. The files in the directory
+        must two types of parquet files with the naming convention:
+            - `"{state_name}_ADDRESS_DEFAULT_GEOCODE_psv.parquet"` for data containing the default
+              geocode data for the state. e.g. "ACT_ADDRESS_DEFAULT_GEOCODE_psv.parquet"
+            - `"{state_name}_ADDRESS_DETAIL_psv.parquet"`: for data containing the detailed address
+              data for the state. e.g. "ACT_ADDRESS_DETAIL_psv.parquet"
+    states : list of str, optional
+        A list of state/territory abbreviations (e.g., ["WA", "ACT"]). If not provided or an empty list,
+        data for all states will be included. Default is an empty list.
+
+    Returns
+    -------
+    tuple of (pl.LazyFrame, pl.LazyFrame)
+        A tuple containing two LazyFrames:
+            - The merged ADDRESS_DEFAULT_GEOCODE data for the specified states, with an added "STATE" column.
+            - The merged ADDRESS_DETAIL data for the specified states.
+
+    Notes
+    -----
+    Expected columns:
+    - `ADDRESS_DEFAULT_GEOCODE` files should include the following columns:
+        - "ADDRESS_DETAIL_PID"
+        - "GEOCODE_TYPE_CODE"
+        - "LATITUDE"
+        - "LONGITUDE"
+        - "STATE"
+    - `ADDRESS_DETAIL` files should include the following columns:
+        - "ADDRESS_DETAIL_PID"
+        - "FLAT_TYPE_CODE"
+        - "POSTCODE"
+    """
+    # List of all state codes
+    all_state_codes: list[
+        Literal["NSW", "ACT", "VIC", "QLD", "SA", "WA", "TAS", "NT", "OT"]
+    ] = ["NSW", "ACT", "VIC", "QLD", "SA", "WA", "TAS", "NT", "OT"]
+
+    # If the states list is empty, use all states
+    if not states:
+        states = all_state_codes
+
+    # Use read_spreadsheets to load the files
+    all_files = read_spreadsheets(gnaf_path, "parquet")
+
+    # Filter out ADDRESS_DEFAULT_GEOCODE and ADDRESS_DETAIL files
+    geocode_files = {
+        key: lf.with_columns(pl.lit(state_name).alias("STATE"))
+        for state_name in states
+        for key, lf in all_files.items()
+        if f"{state_name}_ADDRESS_DEFAULT_GEOCODE" in key
+        and isinstance(lf, pl.LazyFrame)
+    }
+
+    detail_files = {
+        key: lf.select(["ADDRESS_DETAIL_PID", "FLAT_TYPE_CODE", "POSTCODE"])
+        for state_name in states
+        for key, lf in all_files.items()
+        if f"{state_name}_ADDRESS_DETAIL" in key and isinstance(lf, pl.LazyFrame)
+    }
+
+    # Concatenate all LazyFrames
+    default_geocode_lf = (
+        pl.concat(list(geocode_files.values())) if geocode_files else pl.LazyFrame()
+    )
+    address_detail_lf = (
+        pl.concat(list(detail_files.values())) if detail_files else pl.LazyFrame()
+    )
+
+    return default_geocode_lf, address_detail_lf
+
+
+def filter_and_join_gnaf_frames(
+    default_geocode_lf: pl.LazyFrame,
+    address_detail_lf: pl.LazyFrame,
+    building_types: list[str] = [],
+    postcodes: list[int] = [],
 ) -> pl.LazyFrame:
     """
-    Filters the LazyFrame to include only rows with specified SA1 area codes.
+    Filters and joins ADDRESS_DEFAULT_GEOCODE and ADDRESS_DETAIL LazyFrames on `building_types` and `postcodes`.
+
+    Parameters
+    ----------
+    default_geocode_lf : pl.LazyFrame
+        LazyFrame containing ADDRESS_DEFAULT_GEOCODE data. Must have the columns:
+            - "ADDRESS_DETAIL_PID": for joining with `address_detail_lf`.
+    address_detail_lf : pl.LazyFrame
+        LazyFrame containing ADDRESS_DETAIL data. Must have the column:
+            - "ADDRESS_DETAIL_PID": for joining with `default_geocode_lf`.
+            - "FLAT_TYPE_CODE": building type information.
+            - "POSTCODE": postcode of the address.
+    building_types : list of str, optional
+        Building types to filter by in the "FLAT_TYPE_CODE" column of `address_detail_lf`
+        (e.g., ["flat", "unit"]). If empty, no filtering is applied.
+    postcodes : list of int, optional
+        Postcodes to filter by in the "POSTCODE" column of `address_detail_lf`.
+        If empty, no filtering is applied.
+
+    Returns
+    -------
+    pl.LazyFrame
+        Joined LazyFrame with applied filters, if specified.
+
+    Example
+    -------
+    >>> default_geocode_lf, address_detail_lf = load_gnaf_files_by_states("/path/to/gnaf", ["ACT", "NSW"])
+    >>> filtered_lf = filter_and_join_gnaf_frames(
+    ...     default_geocode_lf,
+    ...     address_detail_lf,
+    ...     building_types=["flat", "unit"],
+    ...     postcodes=[2000, 2600]
+    ... )
+    >>> filtered_lf.collect()
+    """
+    # Replace null values in FLAT_TYPE_CODE with "unknown" and convert all values to lowercase
+    address_detail_lf = address_detail_lf.with_columns(
+        pl.col("FLAT_TYPE_CODE")
+        .fill_null("unknown")  # Replace all null values with "unknown"
+        .str.to_lowercase()  # Convert all values to lowercase
+    )
+
+    # Apply optional filtering based on building_types
+    if building_types:  # Check if the list is not empty
+        address_detail_lf = address_detail_lf.filter(
+            pl.col("FLAT_TYPE_CODE").is_in(building_types)
+        )
+
+    # Apply optional filtering based on postcodes
+    if postcodes:  # Check if the list is not empty
+        address_detail_lf = address_detail_lf.filter(
+            pl.col("POSTCODE").is_in(postcodes)
+        )
+
+    # Join using "ADDRESS_DETAIL_PID" as the key
+    joined_lf = default_geocode_lf.join(
+        address_detail_lf, on="ADDRESS_DETAIL_PID", how="inner"
+    )
+
+    return joined_lf
+
+
+def filter_sa1_regions(
+    lf: pl.LazyFrame, region_codes: list[int], sa1_column: str = "SA1_CODE21"
+) -> pl.LazyFrame:
+    """
+    Filter `lf` to include only rows with specified SA1 area codes.
 
     Parameters
     ----------
     lf : pl.LazyFrame
         The LazyFrame containing SA1 region codes and data to be filtered.
-    region_codes : List[str]
-        A list of SA1 area codes to filter for.
-    SA1_column : str
-        The name of the column containing the SA1 area codes. Defaults to "SA1_CODE_2021".
+    region_codes : List[int], optional
+        A list of SA1 area codes to filter for. If empty, no filtering will be applied.
+    sa1_column : str, optional
+        The name of the column containing the SA1 area codes. Defaults to "SA1_CODE21".
 
     Returns
     -------
     pl.LazyFrame
         A LazyFrame containing only rows with the specified SA1 area codes.
+        If no region_codes are specified, returns the original LazyFrame.
     """
+    if not region_codes:  # If the region_codes list is empty
+        return lf  # Return the original LazyFrame
     return lf.filter(pl.col(sa1_column).is_in(region_codes))

--- a/nhs/utils/string.py
+++ b/nhs/utils/string.py
@@ -54,7 +54,7 @@ def placeholder_matches(
     str_list: list[str],
     pattern: str,
     placeholders: list[str],
-    re_pattern: str = r".*?",
+    re_pattern: str = r".+",
 ) -> list[tuple[str, ...]]:
     """
     Return placeholder values for each string in a list that match pattern.

--- a/scripts/join_shapefile_to_gnaf.py
+++ b/scripts/join_shapefile_to_gnaf.py
@@ -1,0 +1,128 @@
+"""
+Join GNAF dataset with shapefile and cache the result as parquet file
+
+Join is performed using sjoin() from geopandas which require the polars
+LazyFrame to be converted to geopandas GeoDataFrame, an extremely expensive
+operation. This script runs this operation once to avoid repeating it in
+other scripts.
+"""
+
+import sys
+from math import log
+from typing import Literal
+
+import polars as pl
+
+sys.path.append(".")
+sys.path.append("..")
+import argparse
+
+from fiona import supported_drivers
+from loguru import logger
+
+from nhs.config import data_config, logger_config
+from nhs.data import read_shapefile, read_spreadsheets
+from nhs.data.geography import join_coords_with_area, to_geo_dataframe
+from nhs.logging import config_logger
+
+
+def main(
+    gnaf_dir: str,
+    shapefile_dir: str,
+    pattern: str,
+    output_name: str,
+    data_config: dict,
+    extension: str = "parquet",
+    strategy: Literal["join_nearest", "filter"] | None = None,
+):
+    # Required for fiona - reads shapefiles
+    supported_drivers["ESRI Shapefile"] = "rw"
+
+    logger.info(f"Reading GNAF data from {gnaf_dir}...")
+    lfs = read_spreadsheets(gnaf_dir, extension, pattern)
+    gnaf = pl.concat(lfs.values(), how="diagonal_relaxed")  # type: ignore
+
+    logger.info(f"Reading shapefile from {shapefile_dir}...")
+    shapefile = read_shapefile(shapefile_dir, data_config["crs"])
+
+    logger.info("Convert polars LazyFrame to geopandas GeoDataFrame...")
+    coords = to_geo_dataframe(gnaf, data_config["crs"])
+
+    logger.info("Joining areas with points...")
+    joined_coords = join_coords_with_area(coords, shapefile, strategy)
+
+    logger.info(f"Saving joined data to {output_name}...")
+    joined_coords.sink_parquet(output_name)
+    logger.info("Done!")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Join GNAF dataset with shapefile and cache the result as parquet file"
+    )
+    parser.add_argument(
+        "-g",
+        "--gnaf_dir",
+        help="Path to a directory of GNAF datasets.",
+        type=str,
+        default=None,
+    )
+    parser.add_argument(
+        "-s",
+        "--shapefile_dir",
+        help="Path to a shapefile directory",
+        type=str,
+        default=None,
+    )
+    parser.add_argument(
+        "-o",
+        "--output_name",
+        help="Path to an output directory",
+        type=str,
+        default="gnaf.parquet",
+    )
+    parser.add_argument(
+        "-e", "--extension", help="File extension of the output file", default="parquet"
+    )
+    parser.add_argument(
+        "-c",
+        "--config_path",
+        help="Path to a configuration file",
+        type=str,
+        default="configurations.yml",
+    )
+    parser.add_argument(
+        "-p",
+        "--pattern",
+        help="Regex pattern to match files in the directory to process. Defaults to r'[A-Z]+_ADDRESS_DEFAULT_GEOCODE_psv'",
+        type=str,
+        default=r"[A-Z]+_ADDRESS_DEFAULT_GEOCODE_psv",
+    )
+    parser.add_argument(
+        "-n",
+        "--strategy",
+        type=str,
+        help="Strategy to handle failed joins, either 'join_nearest' or 'filter'. If not specified, no action is taken.",
+        default=None,
+    )
+    args = parser.parse_args()
+
+    logger.enable("nhs")
+    try:
+        config_logger(logger_config(args.config_path))
+        data_config = data_config(args.config_path)
+    except Exception as e:
+        logger.critical(
+            f"Failed to load configuration at {args.config_path} with exception {e}, terminating..."
+        )
+        exit(1)
+
+    main(
+        gnaf_dir=args.gnaf_dir or data_config["gnaf_path"],
+        shapefile_dir=args.shapefile_dir or data_config["shapefile_path"],
+        pattern=args.pattern,
+        output_name=args.output_name,
+        extension=args.extension,
+        data_config=data_config,
+        strategy=args.strategy,
+    )

--- a/scripts/join_structures_with_shapefile_areas.py
+++ b/scripts/join_structures_with_shapefile_areas.py
@@ -4,7 +4,6 @@ from typing import Literal
 
 import geopandas as gpd
 import polars as pl
-from attr.validators import in_
 from context import nhs
 from fiona.drvsupport import supported_drivers
 from loguru import logger

--- a/tests/test_data/test_filter.py
+++ b/tests/test_data/test_filter.py
@@ -11,48 +11,59 @@ filter_sa1_regions = nhs.data.filter.filter_sa1_regions
 read_spreadsheets = nhs.data.handling.read_spreadsheets
 
 
-
 @pytest.fixture
 def sample_geocode_data():
-    return pl.DataFrame({
-        "ADDRESS_DETAIL_PID": ["1001", "1002"],
-        "LATITUDE": [34.5, 35.0],
-        "LONGITUDE": [150.3, 149.1],
-    }).lazy()
+    return pl.DataFrame(
+        {
+            "ADDRESS_DETAIL_PID": ["1001", "1002"],
+            "LATITUDE": [34.5, 35.0],
+            "LONGITUDE": [150.3, 149.1],
+        }
+    ).lazy()
 
 
 @pytest.fixture
 def sample_detail_data():
-    return pl.DataFrame({
-        "ADDRESS_DETAIL_PID": ["1001", "1002"],
-        "FLAT_TYPE_CODE": ["flat", "unit"],
-        "POSTCODE": [2000, 2600],
-    }).lazy()
+    return pl.DataFrame(
+        {
+            "ADDRESS_DETAIL_PID": ["1001", "1002"],
+            "FLAT_TYPE_CODE": ["flat", "unit"],
+            "POSTCODE": [2000, 2600],
+        }
+    ).lazy()
 
 
 class TestLoadGnafFilesByStates:
-    
+
     @patch("nhs.data.filter.read_spreadsheets")
-    def test_load_files_for_valid_states(self, mock_read_spreadsheets, sample_geocode_data, sample_detail_data):
+    def test_load_files_for_valid_states(
+        self, mock_read_spreadsheets, sample_geocode_data, sample_detail_data
+    ):
         mock_read_spreadsheets.return_value = {
             "NSW_ADDRESS_DEFAULT_GEOCODE.parquet": sample_geocode_data,
             "NSW_ADDRESS_DETAIL.parquet": sample_detail_data,
         }
 
-        result_geocode_lf, result_detail_lf = load_gnaf_files_by_states("/fake/path", ["NSW"])
+        result_geocode_lf, result_detail_lf = load_gnaf_files_by_states(
+            "/fake/path", ["NSW"]
+        )
 
-        expected_geocode = pl.DataFrame({
-            "ADDRESS_DETAIL_PID": ["1001", "1002"],
-            "LATITUDE": [34.5, 35.0],
-            "LONGITUDE": [150.3, 149.1],
-            "STATE": ["NSW", "NSW"],
-        })
+        expected_geocode = pl.DataFrame(
+            {
+                "ADDRESS_DETAIL_PID": ["1001", "1002"],
+                "LATITUDE": [34.5, 35.0],
+                "LONGITUDE": [150.3, 149.1],
+                "STATE": ["NSW", "NSW"],
+            }
+        )
 
-        expected_detail = pl.DataFrame({
-            "ADDRESS_DETAIL_PID": ["1001", "1002"],
-            "FLAT_TYPE_CODE": ["flat", "unit"],
-            "POSTCODE": [2000, 2600],
-        })
+        expected_detail = pl.DataFrame(
+            {
+                "ADDRESS_DETAIL_PID": ["1001", "1002"],
+                "FLAT_TYPE_CODE": ["flat", "unit"],
+                "POSTCODE": [2000, 2600],
+            }
+        )
 
         assert result_geocode_lf.collect().to_dicts() == expected_geocode.to_dicts()
         assert result_detail_lf.collect().to_dicts() == expected_detail.to_dicts()
@@ -60,10 +71,16 @@ class TestLoadGnafFilesByStates:
     @patch("nhs.data.filter.read_spreadsheets")
     def test_load_files_with_no_matching_states(self, mock_read_spreadsheets):
         mock_read_spreadsheets.return_value = {}
-        result_geocode_lf, result_detail_lf = load_gnaf_files_by_states("/fake/path", ["VIC"])
+        result_geocode_lf, result_detail_lf = load_gnaf_files_by_states(
+            "/fake/path", ["VIC"]
+        )
 
-        expected_geocode = pl.DataFrame({"ADDRESS_DETAIL_PID": [], "LATITUDE": [], "LONGITUDE": [], "STATE": []})
-        expected_detail = pl.DataFrame({"ADDRESS_DETAIL_PID": [], "FLAT_TYPE_CODE": [], "POSTCODE": []})
+        expected_geocode = pl.DataFrame(
+            {"ADDRESS_DETAIL_PID": [], "LATITUDE": [], "LONGITUDE": [], "STATE": []}
+        )
+        expected_detail = pl.DataFrame(
+            {"ADDRESS_DETAIL_PID": [], "FLAT_TYPE_CODE": [], "POSTCODE": []}
+        )
 
         assert result_geocode_lf.collect().to_dicts() == expected_geocode.to_dicts()
         assert result_detail_lf.collect().to_dicts() == expected_detail.to_dicts()
@@ -71,44 +88,58 @@ class TestLoadGnafFilesByStates:
     @patch("nhs.data.filter.read_spreadsheets")
     def test_load_files_for_multiple_states(self, mock_read_spreadsheets):
         mock_read_spreadsheets.return_value = {
-            "NSW_ADDRESS_DEFAULT_GEOCODE.parquet": pl.DataFrame({
-                "ADDRESS_DETAIL_PID": ["1001", "1002"],
-                "LATITUDE": [34.5, 35.0],
-                "LONGITUDE": [150.3, 149.1],
-                "STATE": ["NSW", "NSW"],
-            }).lazy(),
-            "ACT_ADDRESS_DEFAULT_GEOCODE.parquet": pl.DataFrame({
-                "ADDRESS_DETAIL_PID": ["1234", "4321"],
-                "LATITUDE": [33.9, 34.4],
-                "LONGITUDE": [149.8, 150.1],
-                "STATE": ["ACT", "ACT"],
-            }).lazy(),
-            "NSW_ADDRESS_DETAIL.parquet": pl.DataFrame({
-                "ADDRESS_DETAIL_PID": ["1001", "1002"],
-                "FLAT_TYPE_CODE": ["flat", "unit"],
-                "POSTCODE": [2000, 2600],
-            }).lazy(),
-            "ACT_ADDRESS_DETAIL.parquet": pl.DataFrame({
-                "ADDRESS_DETAIL_PID": ["1234", "4321"],
-                "FLAT_TYPE_CODE": ["apartment", "house"],
-                "POSTCODE": [2610, 2620],
-            }).lazy(),
+            "NSW_ADDRESS_DEFAULT_GEOCODE.parquet": pl.DataFrame(
+                {
+                    "ADDRESS_DETAIL_PID": ["1001", "1002"],
+                    "LATITUDE": [34.5, 35.0],
+                    "LONGITUDE": [150.3, 149.1],
+                    "STATE": ["NSW", "NSW"],
+                }
+            ).lazy(),
+            "ACT_ADDRESS_DEFAULT_GEOCODE.parquet": pl.DataFrame(
+                {
+                    "ADDRESS_DETAIL_PID": ["1234", "4321"],
+                    "LATITUDE": [33.9, 34.4],
+                    "LONGITUDE": [149.8, 150.1],
+                    "STATE": ["ACT", "ACT"],
+                }
+            ).lazy(),
+            "NSW_ADDRESS_DETAIL.parquet": pl.DataFrame(
+                {
+                    "ADDRESS_DETAIL_PID": ["1001", "1002"],
+                    "FLAT_TYPE_CODE": ["flat", "unit"],
+                    "POSTCODE": [2000, 2600],
+                }
+            ).lazy(),
+            "ACT_ADDRESS_DETAIL.parquet": pl.DataFrame(
+                {
+                    "ADDRESS_DETAIL_PID": ["1234", "4321"],
+                    "FLAT_TYPE_CODE": ["apartment", "house"],
+                    "POSTCODE": [2610, 2620],
+                }
+            ).lazy(),
         }
 
-        result_geocode_lf, result_detail_lf = load_gnaf_files_by_states("/fake/path", ["NSW", "ACT"])
+        result_geocode_lf, result_detail_lf = load_gnaf_files_by_states(
+            "/fake/path", ["NSW", "ACT"]
+        )
 
-        expected_geocode = pl.DataFrame({
-            "ADDRESS_DETAIL_PID": ["1001", "1002", "1234", "4321"],
-            "LATITUDE": [34.5, 35.0, 33.9, 34.4],
-            "LONGITUDE": [150.3, 149.1, 149.8, 150.1],
-            "STATE": ["NSW", "NSW", "ACT", "ACT"],
-        })
+        expected_geocode = pl.DataFrame(
+            {
+                "ADDRESS_DETAIL_PID": ["1001", "1002", "1234", "4321"],
+                "LATITUDE": [34.5, 35.0, 33.9, 34.4],
+                "LONGITUDE": [150.3, 149.1, 149.8, 150.1],
+                "STATE": ["NSW", "NSW", "ACT", "ACT"],
+            }
+        )
 
-        expected_detail = pl.DataFrame({
-            "ADDRESS_DETAIL_PID": ["1001", "1002", "1234", "4321"],
-            "FLAT_TYPE_CODE": ["flat", "unit", "apartment", "house"],
-            "POSTCODE": [2000, 2600, 2610, 2620],
-        })
+        expected_detail = pl.DataFrame(
+            {
+                "ADDRESS_DETAIL_PID": ["1001", "1002", "1234", "4321"],
+                "FLAT_TYPE_CODE": ["flat", "unit", "apartment", "house"],
+                "POSTCODE": [2000, 2600, 2610, 2620],
+            }
+        )
 
         assert result_geocode_lf.collect().to_dicts() == expected_geocode.to_dicts()
         assert result_detail_lf.collect().to_dicts() == expected_detail.to_dicts()
@@ -118,34 +149,54 @@ class TestFilterAndJoinGnafFrames:
 
     @pytest.fixture
     def default_geocode_data(self):
-        return pl.DataFrame({
-            "ADDRESS_DETAIL_PID": ["1001", "1002", "1003"],
-            "LATITUDE": [34.5, 35.0, 36.0],
-            "LONGITUDE": [150.3, 149.1, 148.5],
-        }).lazy()
+        return pl.DataFrame(
+            {
+                "ADDRESS_DETAIL_PID": ["1001", "1002", "1003"],
+                "LATITUDE": [34.5, 35.0, 36.0],
+                "LONGITUDE": [150.3, 149.1, 148.5],
+            }
+        ).lazy()
 
     @pytest.fixture
     def address_detail_data(self):
-        return pl.DataFrame({
-            "ADDRESS_DETAIL_PID": ["1001", "1002", "1003"],
-            "FLAT_TYPE_CODE": ["Flat", None, "Unit"],
-            "POSTCODE": [2000, 2600, 3000],
-        }).lazy()
+        return pl.DataFrame(
+            {
+                "ADDRESS_DETAIL_PID": ["1001", "1002", "1003"],
+                "FLAT_TYPE_CODE": ["Flat", None, "Unit"],
+                "POSTCODE": [2000, 2600, 3000],
+            }
+        ).lazy()
 
-    @pytest.mark.parametrize("building_types,postcodes,expected_pids", [
-        ([], [], ["1001", "1002", "1003"]),  # No filters
-        (["flat"], [], ["1001"]),  # Filter by building type
-        ([], [2600], ["1002"]),  # Filter by postcode
-        (["unit"], [3000], ["1003"]),  # Filter by both building type and postcode
-    ])
-    def test_filter_and_join(self, default_geocode_data, address_detail_data, building_types, postcodes, expected_pids):
-        result_lf = filter_and_join_gnaf_frames(default_geocode_data, address_detail_data, building_types, postcodes)
-        result_pids = result_lf.collect().select("ADDRESS_DETAIL_PID").to_series().to_list()
+    @pytest.mark.parametrize(
+        "building_types,postcodes,expected_pids",
+        [
+            ([], [], ["1001", "1002", "1003"]),  # No filters
+            (["flat"], [], ["1001"]),  # Filter by building type
+            ([], [2600], ["1002"]),  # Filter by postcode
+            (["unit"], [3000], ["1003"]),  # Filter by both building type and postcode
+        ],
+    )
+    def test_filter_and_join(
+        self,
+        default_geocode_data,
+        address_detail_data,
+        building_types,
+        postcodes,
+        expected_pids,
+    ):
+        result_lf = filter_and_join_gnaf_frames(
+            default_geocode_data, address_detail_data, building_types, postcodes
+        )
+        result_pids = (
+            result_lf.collect().select("ADDRESS_DETAIL_PID").to_series().to_list()
+        )
 
         assert result_pids == expected_pids
 
     def test_no_matching_filters(self, default_geocode_data, address_detail_data):
-        result_lf = filter_and_join_gnaf_frames(default_geocode_data, address_detail_data, building_types=["apartment"])
+        result_lf = filter_and_join_gnaf_frames(
+            default_geocode_data, address_detail_data, building_types=["apartment"]
+        )
         assert result_lf.collect().height == 0
 
 

--- a/tests/test_data/test_filter.py
+++ b/tests/test_data/test_filter.py
@@ -1,9 +1,152 @@
+from unittest.mock import patch
+
 import polars as pl
 import pytest
 
 from ..context import nhs
 
+load_gnaf_files_by_states = nhs.data.filter.load_gnaf_files_by_states
+filter_and_join_gnaf_frames = nhs.data.filter.filter_and_join_gnaf_frames
 filter_sa1_regions = nhs.data.filter.filter_sa1_regions
+read_spreadsheets = nhs.data.handling.read_spreadsheets
+
+
+
+@pytest.fixture
+def sample_geocode_data():
+    return pl.DataFrame({
+        "ADDRESS_DETAIL_PID": ["1001", "1002"],
+        "LATITUDE": [34.5, 35.0],
+        "LONGITUDE": [150.3, 149.1],
+    }).lazy()
+
+
+@pytest.fixture
+def sample_detail_data():
+    return pl.DataFrame({
+        "ADDRESS_DETAIL_PID": ["1001", "1002"],
+        "FLAT_TYPE_CODE": ["flat", "unit"],
+        "POSTCODE": [2000, 2600],
+    }).lazy()
+
+
+class TestLoadGnafFilesByStates:
+    
+    @patch("nhs.data.filter.read_spreadsheets")
+    def test_load_files_for_valid_states(self, mock_read_spreadsheets, sample_geocode_data, sample_detail_data):
+        mock_read_spreadsheets.return_value = {
+            "NSW_ADDRESS_DEFAULT_GEOCODE.parquet": sample_geocode_data,
+            "NSW_ADDRESS_DETAIL.parquet": sample_detail_data,
+        }
+
+        result_geocode_lf, result_detail_lf = load_gnaf_files_by_states("/fake/path", ["NSW"])
+
+        expected_geocode = pl.DataFrame({
+            "ADDRESS_DETAIL_PID": ["1001", "1002"],
+            "LATITUDE": [34.5, 35.0],
+            "LONGITUDE": [150.3, 149.1],
+            "STATE": ["NSW", "NSW"],
+        })
+
+        expected_detail = pl.DataFrame({
+            "ADDRESS_DETAIL_PID": ["1001", "1002"],
+            "FLAT_TYPE_CODE": ["flat", "unit"],
+            "POSTCODE": [2000, 2600],
+        })
+
+        assert result_geocode_lf.collect().to_dicts() == expected_geocode.to_dicts()
+        assert result_detail_lf.collect().to_dicts() == expected_detail.to_dicts()
+
+    @patch("nhs.data.filter.read_spreadsheets")
+    def test_load_files_with_no_matching_states(self, mock_read_spreadsheets):
+        mock_read_spreadsheets.return_value = {}
+        result_geocode_lf, result_detail_lf = load_gnaf_files_by_states("/fake/path", ["VIC"])
+
+        expected_geocode = pl.DataFrame({"ADDRESS_DETAIL_PID": [], "LATITUDE": [], "LONGITUDE": [], "STATE": []})
+        expected_detail = pl.DataFrame({"ADDRESS_DETAIL_PID": [], "FLAT_TYPE_CODE": [], "POSTCODE": []})
+
+        assert result_geocode_lf.collect().to_dicts() == expected_geocode.to_dicts()
+        assert result_detail_lf.collect().to_dicts() == expected_detail.to_dicts()
+
+    @patch("nhs.data.filter.read_spreadsheets")
+    def test_load_files_for_multiple_states(self, mock_read_spreadsheets):
+        mock_read_spreadsheets.return_value = {
+            "NSW_ADDRESS_DEFAULT_GEOCODE.parquet": pl.DataFrame({
+                "ADDRESS_DETAIL_PID": ["1001", "1002"],
+                "LATITUDE": [34.5, 35.0],
+                "LONGITUDE": [150.3, 149.1],
+                "STATE": ["NSW", "NSW"],
+            }).lazy(),
+            "ACT_ADDRESS_DEFAULT_GEOCODE.parquet": pl.DataFrame({
+                "ADDRESS_DETAIL_PID": ["1234", "4321"],
+                "LATITUDE": [33.9, 34.4],
+                "LONGITUDE": [149.8, 150.1],
+                "STATE": ["ACT", "ACT"],
+            }).lazy(),
+            "NSW_ADDRESS_DETAIL.parquet": pl.DataFrame({
+                "ADDRESS_DETAIL_PID": ["1001", "1002"],
+                "FLAT_TYPE_CODE": ["flat", "unit"],
+                "POSTCODE": [2000, 2600],
+            }).lazy(),
+            "ACT_ADDRESS_DETAIL.parquet": pl.DataFrame({
+                "ADDRESS_DETAIL_PID": ["1234", "4321"],
+                "FLAT_TYPE_CODE": ["apartment", "house"],
+                "POSTCODE": [2610, 2620],
+            }).lazy(),
+        }
+
+        result_geocode_lf, result_detail_lf = load_gnaf_files_by_states("/fake/path", ["NSW", "ACT"])
+
+        expected_geocode = pl.DataFrame({
+            "ADDRESS_DETAIL_PID": ["1001", "1002", "1234", "4321"],
+            "LATITUDE": [34.5, 35.0, 33.9, 34.4],
+            "LONGITUDE": [150.3, 149.1, 149.8, 150.1],
+            "STATE": ["NSW", "NSW", "ACT", "ACT"],
+        })
+
+        expected_detail = pl.DataFrame({
+            "ADDRESS_DETAIL_PID": ["1001", "1002", "1234", "4321"],
+            "FLAT_TYPE_CODE": ["flat", "unit", "apartment", "house"],
+            "POSTCODE": [2000, 2600, 2610, 2620],
+        })
+
+        assert result_geocode_lf.collect().to_dicts() == expected_geocode.to_dicts()
+        assert result_detail_lf.collect().to_dicts() == expected_detail.to_dicts()
+
+
+class TestFilterAndJoinGnafFrames:
+
+    @pytest.fixture
+    def default_geocode_data(self):
+        return pl.DataFrame({
+            "ADDRESS_DETAIL_PID": ["1001", "1002", "1003"],
+            "LATITUDE": [34.5, 35.0, 36.0],
+            "LONGITUDE": [150.3, 149.1, 148.5],
+        }).lazy()
+
+    @pytest.fixture
+    def address_detail_data(self):
+        return pl.DataFrame({
+            "ADDRESS_DETAIL_PID": ["1001", "1002", "1003"],
+            "FLAT_TYPE_CODE": ["Flat", None, "Unit"],
+            "POSTCODE": [2000, 2600, 3000],
+        }).lazy()
+
+    @pytest.mark.parametrize("building_types,postcodes,expected_pids", [
+        ([], [], ["1001", "1002", "1003"]),  # No filters
+        (["flat"], [], ["1001"]),  # Filter by building type
+        ([], [2600], ["1002"]),  # Filter by postcode
+        (["unit"], [3000], ["1003"]),  # Filter by both building type and postcode
+    ])
+    def test_filter_and_join(self, default_geocode_data, address_detail_data, building_types, postcodes, expected_pids):
+        result_lf = filter_and_join_gnaf_frames(default_geocode_data, address_detail_data, building_types, postcodes)
+        result_pids = result_lf.collect().select("ADDRESS_DETAIL_PID").to_series().to_list()
+
+        assert result_pids == expected_pids
+
+    def test_no_matching_filters(self, default_geocode_data, address_detail_data):
+        result_lf = filter_and_join_gnaf_frames(default_geocode_data, address_detail_data, building_types=["apartment"])
+        assert result_lf.collect().height == 0
 
 
 class TestFilterSa1RegionCodes:
@@ -12,7 +155,7 @@ class TestFilterSa1RegionCodes:
     @pytest.fixture
     def sample_lazyframe(self):
         data = {
-            "SA1_CODE_2021": ["123456", "789012", "345678", "901234", "567890"],
+            "SA1_CODE21": [123456, 789012, 345678, 901234, 567890],
             "value": [10, 20, 30, 40, 50],
         }
         return pl.DataFrame(data).lazy()
@@ -20,28 +163,26 @@ class TestFilterSa1RegionCodes:
     def test_filter_with_valid_region_codes(self, sample_lazyframe):
         # Filtering with valid region codes
         result = filter_sa1_regions(
-            sample_lazyframe, ["123456", "901234"], "SA1_CODE_2021"
+            sample_lazyframe, [123456, 901234], "SA1_CODE21"
         ).collect()
 
-        expected_data = {"SA1_CODE_2021": ["123456", "901234"], "value": [10, 40]}
+        expected_data = {"SA1_CODE21": [123456, 901234], "value": [10, 40]}
 
         expected = pl.DataFrame(expected_data)
         assert result.to_dicts() == expected.to_dicts()
 
     def test_filter_with_empty_region_codes(self, sample_lazyframe):
-        # Test with empty region codes (should return an empty LazyFrame)
-        result = filter_sa1_regions(sample_lazyframe, [], "SA1_CODE_2021").collect()
+        # Test with empty region codes (should return the original LazyFrame)
+        result = filter_sa1_regions(sample_lazyframe, [], "SA1_CODE21").collect()
 
-        # Expect an empty DataFrame when no region codes are provided
-        expected = pl.DataFrame({"SA1_CODE_2021": [], "value": []})
+        # Expect the original DataFrame when no region codes are provided
+        expected = sample_lazyframe.collect()
 
         assert result.to_dicts() == expected.to_dicts()
 
     def test_filter_with_no_matching_codes(self, sample_lazyframe):
         # Test with region codes that don't match any rows (should return an empty DataFrame)
-        result = filter_sa1_regions(
-            sample_lazyframe, ["999999"], "SA1_CODE_2021"
-        ).collect()
+        result = filter_sa1_regions(sample_lazyframe, [999999], "SA1_CODE21").collect()
 
-        expected = pl.DataFrame({"SA1_CODE_2021": [], "value": []})
+        expected = pl.DataFrame({"SA1_CODE21": [], "value": []})
         assert result.to_dicts() == expected.to_dicts()


### PR DESCRIPTION
---
Title: "Closes #30"
---

# **Summary of Changes**
This pull request introduces three new functions to handle GNAF data filtering and joins based on specific criteria such as building types, postcodes, and SA1 region codes.

**Functions Implemented：**
1. load_gnaf_files_by_states:
	•When Called: This function is called at the start of the process to load the GNAF geocoding (ADDRESS_DEFAULT_GEOCODE) and address details (ADDRESS_DETAIL) data for specific states.
	•Purpose: It loads and filters files for the specified states from the GNAF directory.
	•Returns: Two LazyFrame objects:
	- default_geocode_lf: Contains GNAF geocoding data with an added STATE column.
	- address_detail_lf: Contains address details filtered by state.

2. filter_and_join_gnaf_frames:
	•When Called: This function is called after load_gnaf_files_by_states to join the geocoding data (default_geocode_lf) and address details (address_detail_lf) on ADDRESS_DETAIL_PID. Optional filtering is applied based on building types and postcodes.
	•Purpose: It filters and joins the GNAF data based on the specified building types and postcodes.
	•Returns: A LazyFrame with rows matching the specified building types and postcodes, or all rows if no filtering criteria are provided.

3. filter_sa1_regions:
	•When Called: This function is called after the gnaf data has been joined and processed with the shapefile data (SA1 geographies). It filters the resulting data by SA1 codes.
	•Purpose: Filters the LazyFrame to include only rows with the specified SA1 area codes.
	•Returns: A LazyFrame containing only rows with the specified SA1 area codes. If no region codes are provided, the function returns the original LazyFrame without filtering.

### **Optional Further Details**
Test cases in test_filter.py have been updated to cover the following scenarios for the new functions:
1. load_gnaf_files_by_states:
	•Load files for specific states (e.g., NSW, ACT).
	•Return empty LazyFrames when no files are found for the state.
	•Handle multiple states simultaneously.
2. filter_and_join_gnaf_frames:
	•Filter by building types.
	•Filter by postcodes.
	•Test with mixed valid and invalid building types/postcodes.
	•Handle empty and unmatched building type filters.
3. filter_sa1_regions:
	•Filter based on valid SA1 region codes.
	•Return the original LazyFrame when no SA1 codes are provided.
	•Handle cases where no SA1 codes match.


# **Checklist:**
- [x] My code follows the code style of this project.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests prove my fix is effective or that my feature works.
- [x] I have annotated added types appropriately.


